### PR TITLE
Use generator expression for comparison, and use casefold to allow non-ASCII lowercase conversion

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -50,8 +50,7 @@ async def on_message(message):
             await message.add_reaction("🤬")
             return
 
-        for x in good_mornings:
-            if x in string:
-                print("gm detected", message.content)
-                await message.add_reaction("☀️")
-                return
+        if any(element in string for element in good_mornings):
+            print("gm detected", message.content)
+            await message.add_reaction("☀️")
+            return

--- a/bot.py
+++ b/bot.py
@@ -43,10 +43,9 @@ async def on_message(message):
     if message.author == client.user:
         await message.add_reaction("☀️")
         return
-    string = message.content
-    string = string.lower()
+    string = message.content.casefold()
     if time.localtime().tm_hour >= 6 and time.localtime().tm_hour <= 12:
-        if  "bad morning" in string:
+        if "bad morning" in string:
             print("bad morning detected")
             await message.add_reaction("🤬")
             return


### PR DESCRIPTION
Using a generator expression improves the clarity somewhat and provides minor performance gains (especially if the list of `good_mornings` increases in the future).

Using `.casefold()` causes the entire range of unicode characters to be converted to lowercase which appears to be desired, while `.lower()` is limited to the 256 ASCII characters. Performance in both methods is effectively the same.

This has not been tested by me using a live bot, so I hope you can test this yourself before any merge.

Thanks!