### PR TITLE
Docker Support & README Creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:latest
 
 FROM gorialis/discord.py
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3
+
+FROM gorialis/discord.py
+
+RUN mkdir -p /usr/src/MorningBot
+
+WORKDIR /usr/src/MorningBot
+
+COPY . .
+
+CMD ["python3", "main.py"]

--- a/README.md
+++ b/README.md
@@ -2,32 +2,38 @@
 
 MorningBot is a Discord Bot built for CS++'s Discord Server. It reacts to all morning messages and has other fun features like leaderboards and hidden reacts.
 
-## Installation & Deployment
+## Installation, Deployment and Development
 
-When deploying, you may choose to deploy as a container, or deploy directly to your machine, any instruction that is Docker-only will be marked with a 🐳, direct deployment will be marked with a 🚀.
+When deploying, you may choose to deploy as a container, or deploy directly to your machine, any instruction that is Docker-only will be marked with a 🐳, direct deployment only will be marked with a 🚀.
 
-1. Clone the repository and install the dependencies.
-
+### Installation
+1. Clone the repository
 ```bash
 git clone
+```
+
+2. 🚀 Install the dependencies.
+```bash
 pip install -r requirements.txt
 ```
 
-2. Create a file called 'token' and put in your bot token.
+### Deployment and Development
 
-3. 🚀 Run the bot.
+3. Create a file called 'token' and put in your bot token.
+
+4. 🚀 Run the bot.
 
 ```bash
 python3 main.py
 ```
 
-3. 🐳 Build the container.
+5. 🐳 Build the container.
 
 ```bash
 docker build -t morningbot .
 ```
 
-4. 🐳 Run the container.
+6. 🐳 Run the container.
 
 ```bash
 docker run -d --name morningbot morningbot

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# MorningBot
+
+MorningBot is a Discord Bot built for CS++'s Discord Server. It reacts to all morning messages and has other fun features like leaderboards and hidden reacts.
+
+## Installation & Deployment
+
+When deploying, you may choose to deploy as a container, or deploy directly to your machine, any instruction that is Docker-only will be marked with a 🐳, direct deployment will be marked with a 🚀.
+
+1. Clone the repository and install the dependencies.
+
+```bash
+git clone
+pip install -r requirements.txt
+```
+
+2. Create a file called 'token' and put in your bot token.
+
+3. 🚀 Run the bot.
+
+```bash
+python3 main.py
+```
+
+3. 🐳 Build the container.
+
+```bash
+docker build -t morningbot .
+```
+
+4. 🐳 Run the container.
+
+```bash
+docker run -d --name morningbot morningbot
+```

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,0 @@
-set -xe
-
-cat token | xargs python3 main.py

--- a/main.py
+++ b/main.py
@@ -1,8 +1,10 @@
 import bot
 import sys
 
-token = open("token", "r")
-
-if __name__ == "__main__":
+def main():
+    token = open("token", "r")
     bot.client.run(token.read()) 
     token.close()
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -1,5 +1,8 @@
 import bot
 import sys
 
+token = open("token", "r")
+
 if __name__ == "__main__":
-    bot.client.run(sys.argv[1]) 
+    bot.client.run(token.read()) 
+    token.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+discord


### PR DESCRIPTION
This PR adds a Dockerfile, modifies main.py for easier start-up and adds a README for a project overview and deployment information.

# Dockerfile
The Dockerfile pulls from Gorialis' [DiscordPy](https://github.com/Gorialis/discord.py-docker) Docker image and builds a MorningBot container from that.

# Main.py Changes
The token is no longer passed as an argument to the bot, but instead is read from file with the `open()` command.

# README
The README contains a short brief about the project as well as instructions on deployment for both Docker and direct methods.