### PR TITLE
fixed easter egg prompts not reading correctly

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -99,10 +99,11 @@ to quickly create a Cobra application.`,
 			content := message.Content
 			logger.Info(message.Content)
 
+			//Easter Egg Phrases Checker
 			newContent := strings.ToLower(content)
 
 			for phrase, emoji := range config.EasterEggPhrases {
-				if !strings.Contains(phrase, newContent) {
+				if !strings.Contains(newContent, phrase) {
 					continue
 				}
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -46,6 +46,7 @@ goodMorningPhrases:
   - "suno pona"
   - "bonan matenon"
   - "bon matino"
+  - "dzień dobry"
 goodMorningGifUrls:
   - "https://media.giphy.com/media/hHifLbLhEloqfDwWs0/giphy.gif"
   - "https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYXVwbnE0aGxyN2lkcTZ6ZzZ4d2NlYm5ldmJnYmgyZG9lMjQ5OTI3NiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9cw/hVTtBEjpy6hj0OQSFb/giphy.gif"


### PR DESCRIPTION
# Morning bot PR

small change to fix a bug that made the bot too sensitive with trigger messages

As of current the bot scans the user message and check if the full or part of a trigger is in the sentences so:
socks returns true
programmer socks returns true
so returns true
but if the full prompt is used in a sentence:
programmer socks are cool returns false
this was a small typo in the original design with prompt and newcontent being in each others position

no on the repo but in sysadmin chat

## Acceptance Criteria

- [x] Implementation
- [ ] Test Coverage
- [x] Change Reflected in Documentation?
- [ ] CI/CD pipelines configured to accomodate change
